### PR TITLE
A few gas optimizations

### DIFF
--- a/src/StateTree.sol
+++ b/src/StateTree.sol
@@ -9,7 +9,7 @@ library StateTree {
     }
 
     function bitmap(uint256 index) internal pure returns (uint8) {
-        uint8 bytePos = (uint8(bufLength) - 1) - (uint8(index) / 8);
+        uint8 bytePos = (uint8(bufLength) - 1) - (uint8(index) >> 3);
         return bytePos + 1 << (uint8(index) % 8);
     }
 

--- a/src/StateTree.sol
+++ b/src/StateTree.sol
@@ -53,22 +53,46 @@ library StateTree {
 		bytes32 hash = _leaf;
         bytes32 proofElement;
 
-     	for (uint256 d = 0; d < DEPTH; d++) {
-            if ((_bits & 1) == 1) {
-        	    proofElement = _proofs[d];
-            } else {
-                proofElement = get(d);
-            }
+        proofElement = get(0);
+        hash = keccak256(abi.encode(hash, proofElement));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
 
-        	if ((_index & 1) == 1) {
-         		hash = keccak256(abi.encode(proofElement, hash));
-        	} else {
-          		hash = keccak256(abi.encode(hash, proofElement));
-        	}
+        proofElement = _proofs[1];
+        hash = keccak256(abi.encode(proofElement, hash));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
 
-            _bits = _bits >> 1;
-        	_index = _index >> 1;
-      	}
+        proofElement = get(2);
+        hash = keccak256(abi.encode(hash, proofElement));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
+
+        proofElement = _proofs[3];
+        hash = keccak256(abi.encode(proofElement, hash));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
+
+        proofElement = get(4);
+        hash = keccak256(abi.encode(hash, proofElement));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
+
+        proofElement = _proofs[5];
+        hash = keccak256(abi.encode(proofElement, hash));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
+
+        proofElement = get(6);
+        hash = keccak256(abi.encode(hash, proofElement));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
+
+        proofElement = _proofs[7];
+        hash = keccak256(abi.encode(proofElement, hash));
+        _bits = _bits >> 1;
+        _index = _index >> 1;
+        
 		return hash;
     }
 }

--- a/src/StateTree.sol
+++ b/src/StateTree.sol
@@ -66,8 +66,8 @@ library StateTree {
           		hash = keccak256(abi.encode(hash, proofElement));
         	}
 
-            _bits = _bits / 2;
-        	_index = _index / 2;
+            _bits = _bits >> 1;
+        	_index = _index >> 1;
       	}
 		return hash;
     }


### PR DESCRIPTION
- Turning `x / 2` into `x >> 1` (equivalent) saves more than 100 in gas costs. The statement was used 16 times inside the compute function, which should give then a saving of 1600+ gas for each call.
- Splatting the for loop (which was anyway running a constant amount of times) and removing the additional checks on odd and even iterations, saved around 1000 gas compared to the previous version. Although I agree, it's nastier.
- Another division by 8 has been turned into its bitwise equivalent (`x >> 3`), saving around 100 gas for every time it's called. In general: divisions by powers of 2 can be optimized with its bitwise equivalent.

Hopefully, this is not gonna break the correctness.