### PR TITLE
Further gas optimizations

### DIFF
--- a/src/StateTree.sol
+++ b/src/StateTree.sol
@@ -64,6 +64,22 @@ library StateTree {
 		);
 		return compute(_proofs, _bits, _index, _nextLeaf);
 	}
+    
+    function getLeafPA(bytes32 proof, bytes32 hash) internal pure returns (bytes32) {
+        return keccak256(abi.encode(proof, hash));
+    }
+
+    function getLeafAP(bytes32 proof, bytes32 hash) internal pure returns (bytes32) {
+        return keccak256(abi.encode(hash, proof));
+    }
+
+    function getProof(uint index, bytes32[] memory proofs) internal pure returns (bytes32) {
+        return proofs[index];
+    }
+    
+    function getHash(uint index, bytes32[] memory dummy) internal pure returns (bytes32) {
+        return hashes(index);
+    }
 
 	function compute(
       bytes32[] memory _proofs,


### PR DESCRIPTION
The `for` loop in the `compute` function has been expanded. This will save gas from:

- the increment and comparison of the loop iterator
- the check on odd or even `index` and `bits` at every iteration, which is now done only once
- the halving of `index` and `bits` at every iteration

The total gas savings should account for around 1000.

Additionally, the division by 8 of the `bitmap` has been turned into its bitshift counterpart.
